### PR TITLE
fix(build): add electron-builder-sandbox-fix to resolve apparmor sanboxing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "coverage:main": "jest --watchman=false --config jest.config.js --coverage",
     "coverage:renderer": "jest --watchman=false --config jest.web.config.js --coverage"
   },
+  "build": {
+    "afterPack": "electron-builder-sandbox-fix"
+  },
   "lint-staged": {
     "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts,json,jsonc,css,scss,md,yml,yaml}": "biome check --write --no-errors-on-unmatched"
   },
@@ -88,6 +91,7 @@
     "@webgpu/types": "^0.1.69",
     "electron": "^41.2.0",
     "electron-builder": "^26.8.2",
+    "electron-builder-sandbox-fix": "^1.1.1",
     "esbuild": "^0.28.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       electron-builder:
         specifier: ^26.8.2
         version: 26.8.2(electron-builder-squirrel-windows@26.8.2)
+      electron-builder-sandbox-fix:
+        specifier: ^1.1.1
+        version: 1.1.1
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -2096,6 +2099,9 @@ packages:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+
+  electron-builder-sandbox-fix@1.1.1:
+    resolution: {integrity: sha512-+gSiLZ7KZDRr3ATm89eud96QwURauUXMzB2lbzZffkAYMC4yyF2fqq0W2xoTg38eDVFCJThcoyW1p8Ph/unxoA==}
 
   electron-builder-squirrel-windows@26.8.2:
     resolution: {integrity: sha512-kXhajX6DzdIQcTlctVTKoG1oO39JhWcTG0lH7ZEJ4FzPaKJy7KFNfNJUd5BoEmLjv5GlrRZpEOYnniD+LcwNJA==}
@@ -6059,6 +6065,10 @@ snapshots:
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
+
+  electron-builder-sandbox-fix@1.1.1:
+    dependencies:
+      chalk: 4.1.2
 
   electron-builder-squirrel-windows@26.8.2(dmg-builder@26.8.2):
     dependencies:


### PR DESCRIPTION
Currently the LIVI AppImage for Linux will not start on distributions such as Kubuntu 25.10 with AppArmor installed due to the `apparmor_restrict_unprivileged_userns` being enabled by default, breaking sandboxing.

Example error message:
```
[2494:0410/114235.140738:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /tmp/.mount_LIVI-5BMfnhN/chrome-sandbox is owned by root and has mode 4755.
```

The [`electron-builder-sandbox-fix`](https://github.com/gergof/electron-builder-sandbox-fix) hook provides a build level workaround for this issue, which disables sanboxing on affected systems. See [this blog post](https://tamim.blog/post/fix-appimage-sandbox-issues-ubuntu-24-04/) that details the cause of the issue as well as available alternative user workarounds.

This will likely require a more permanent solution due to the `electron-builder-sandbox-fix` dependency presenting its own security implications ([disabling sandboxing by executing a shell script](https://github.com/gergof/electron-builder-sandbox-fix/blob/master/lib/index.js#L23)), however in the short term it allows the AppImage to be used on systems with AppArmor without requiring direct intervention from the user.

Thank you for reviewing this pull request and your active development of the project.