### PR TITLE
feat(bt): make bluetoothd args configurable

### DIFF
--- a/src/main/services/projection/driver/aa/bt/aa-bluetooth.py
+++ b/src/main/services/projection/driver/aa/bt/aa-bluetooth.py
@@ -29,7 +29,7 @@ import dbus.mainloop.glib
 from gi.repository import GLib
 
 from wifi_ap import setup_ap, teardown_ap, get_wlan_mac, AP_IP
-from config import SSID, PASSPHRASE, CHANNEL, PORT as AA_PORT, BTNAME, WIFI_IFACE, BT_ADAPTER
+from config import SSID, PASSPHRASE, CHANNEL, PORT as AA_PORT, BTNAME, WIFI_IFACE, BT_ADAPTER, BT_BLUETOOTHD_ARGS
 
 # ── Debug gate ────────────────────────────────────────────────────────────────
 DEBUG = os.environ.get("DEBUG") == "1"
@@ -89,12 +89,12 @@ def _find_bluetoothd() -> str:
 
 
 def _ensure_noplugins_dropin() -> bool:
-    """Write the `bluetoothd -P *` drop-in."""
+    """Write the bluetoothd drop-in. Args come from BT_BLUETOOTHD_ARGS — see config.py."""
     bluetoothd = _find_bluetoothd()
     content = (
         "[Service]\n"
         "ExecStart=\n"
-        f"ExecStart={bluetoothd} -P *\n"
+        f"ExecStart={bluetoothd} {BT_BLUETOOTHD_ARGS}\n"
     )
 
     restart_needed = False
@@ -108,10 +108,10 @@ def _ensure_noplugins_dropin() -> bool:
         os.makedirs(_DROPIN_DIR, exist_ok=True)
         with open(_DROPIN_CFG, "w") as f:
             f.write(content)
-        dprint(f"[aa-bt] wrote {_DROPIN_CFG} ({bluetoothd} -P *)")
+        dprint(f"[aa-bt] wrote {_DROPIN_CFG} ({bluetoothd} {BT_BLUETOOTHD_ARGS})")
         restart_needed = True
     else:
-        dprint(f"[aa-bt] bluetoothd -P * drop-in already in place ({bluetoothd})")
+        dprint(f"[aa-bt] bluetoothd drop-in already in place ({bluetoothd} {BT_BLUETOOTHD_ARGS})")
 
     return restart_needed
 

--- a/src/main/services/projection/driver/aa/bt/config.py
+++ b/src/main/services/projection/driver/aa/bt/config.py
@@ -56,5 +56,12 @@ PORT         = int(_get_value("LIVI_PORT",     "port",          "5277"))
 WIFI_IFACE   = _get_value("LIVI_WIFI_IFACE",   "wifiInterface", "wlan0")
 
 # ── Bluetooth ─────────────────────────────────────────────────────────────────
-BTNAME       = _get_value("LIVI_BTNAME",       "carName",       "LIVI")
-BT_ADAPTER   = _get_value("LIVI_BT_ADAPTER",   "btAdapter",     "hci0")
+BTNAME            = _get_value("LIVI_BTNAME",            "carName",          "LIVI")
+BT_ADAPTER        = _get_value("LIVI_BT_ADAPTER",        "btAdapter",        "hci0")
+# Args for the bluetoothd drop-in written by setup_bluetoothd_dropin().
+# Default `-P *` disables ALL bluez plugins (preserves historical behavior).
+# Set to `--noplugin=sap` to only disable the SIM-Access plugin: that frees
+# RFCOMM channel 8 for the AA-Custom-Profile while keeping `audio` loaded,
+# so `org.bluez.Media1` stays available and a paralleler A2DP-stream to an
+# external BT-speaker / car-radio remains possible during projection.
+BT_BLUETOOTHD_ARGS = _get_value("LIVI_BT_BLUETOOTHD_ARGS", "btBluetoothdArgs", "-P *")


### PR DESCRIPTION
aa-bluetooth.py writes a systemd drop-in that sets bluetoothd's ExecStart. The default `-P *` (all plugins disabled) was a hammer fix for one specific RFCOMM-channel conflict: the AA-Custom-Profile binds RFCOMM channel 8, which is also hardcoded in bluez's `sap` plugin (profiles/sap/server.c: SAP_SERVER_CHANNEL 8). Disabling every plugin also drops `org.bluez.Media1`, making A2DP streaming to an external BT speaker / car radio impossible for the duration of the projection.

Add `btBluetoothdArgs` (env `LIVI_BT_BLUETOOTHD_ARGS`, default `-P *`) so users can opt in to a narrower disable. Setting `--noplugin=sap` keeps `audio` loaded — Media1 stays available, A2DP-Sink-Streams continue to work in parallel — and only blocks the channel-8 conflict.

Default behavior is unchanged; this is opt-in via config.json / env. Verified on Raspberry Pi 5 (bluez 5.82, Debian Trixie).